### PR TITLE
modified function initConnectionName

### DIFF
--- a/ipsi/src/ipsi.c
+++ b/ipsi/src/ipsi.c
@@ -190,7 +190,22 @@ static int buildConnectionName(char *appName)
  * @return FAILURE: Cannot be able to bind connection name with connection type as per DBUS specification
  */
 static int initConnectionName(char *appName,char *connectionType){
-
+	if(isServer(connectionType)){
+		if (SUCCESS == buildConnectionName(appName)){
+			applicationRole = IPSI_SERVER;
+			return SUCCESS;
+		}
+		else
+			return FAILURE;
+	}
+	else if(isCaller(connectionType)){
+		if(SUCCESS == buildConnectionName(appName)){
+			applicationRole = IPSI_CALLER;
+			return SUCCESS;
+		}
+		else
+			return FAILURE;
+	}
 	return FAILURE;
 }
 


### PR DESCRIPTION
Wrote the initConnectionName function. This is an utility function, that helps in binding connection name with connectionType that severs as an input to low-level communication protocol [Dbus].