### PR TITLE
Bug fix- handle ipsiConnectionType failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 .cproject
 .project
 ipsiTest/report
-ipsi/bin/*
-ipsi/obj/*

--- a/ipsi/bin/.gitignore
+++ b/ipsi/bin/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/ipsi/obj/.gitignore
+++ b/ipsi/obj/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/ipsiTest/runUT.sh
+++ b/ipsiTest/runUT.sh
@@ -49,5 +49,8 @@ echo "*********************************************************"
 echo "**Code Coverage END**"
 echo "*********************************************************"
 echo "*********************************************************"
-echo "**UT completed , See the coverage data in report folder**"
+echo "**Unit Testing completed See the coverage data in report/ folder**"
+echo "Opening Coverage report in Firefox Browser...............!"
+sleep 2
+firefox report/src/index.html &
 echo "*********************************************************"

--- a/ipsiTest/ut_test/Makefile
+++ b/ipsiTest/ut_test/Makefile
@@ -1,6 +1,6 @@
 TEST_ISCALLER = unitTest_isCaller_UT.c
-#TEST_ISSERVER =	unitTest_isServer_UT.c
-#TEST_CONNECTIONTYPE = unitTest_ipsiConnectionType_UT.c
+TEST_ISSERVER =	unitTest_isServer_UT.c
+TEST_CONNECTIONTYPE = unitTest_ipsiConnectionType_UT.c
 TEST_METHODCALL = unitTest_ipsiMethodCall_UT.c
 TEST_REGISTERFUNCTION = unitTest_ipsiRegisterFunction_UT.c
 TEST_LISTEN = unitTest_ipsiListen_UT.c
@@ -15,8 +15,8 @@ COVERAGE= -fprofile-arcs -ftest-coverage
 
 TEST_ALL:
 	$(CXX) $(COVERAGE) $(TEST_INCLUDE) $(TEST_ISCALLER) -o bin/isCaller.ut
-#	$(CXX) $(COVERAGE) $(TEST_INCLUDE) $(TEST_ISSERVER) -o bin/isServer.ut
-#	$(CXX) $(COVERAGE) $(TEST_INCLUDE) $(TEST_CONNECTIONTYPE) -o bin/ConnectionType.ut
+	$(CXX) $(COVERAGE) $(TEST_INCLUDE) $(TEST_ISSERVER) -o bin/isServer.ut
+	$(CXX) $(COVERAGE) $(TEST_INCLUDE) $(TEST_CONNECTIONTYPE) -o bin/ConnectionType.ut
 	$(CXX) $(COVERAGE) $(TEST_INCLUDE) $(TEST_METHODCALL) -o bin/MethodCall.ut
 	$(CXX) $(COVERAGE) $(TEST_INCLUDE) $(TEST_REGISTERFUNCTION) -o bin/RegisterFunction.ut
 	$(CXX) $(COVERAGE) $(TEST_INCLUDE) $(TEST_LISTEN) -o bin/Listen.ut

--- a/ipsiTest/ut_test/unitTest_ipsiConnectionType_UT.c
+++ b/ipsiTest/ut_test/unitTest_ipsiConnectionType_UT.c
@@ -1,0 +1,127 @@
+/**
+ * @file unitTest_ipsiConnectionType_UT.c
+ *
+ * Description: To perform Unit Testing on ipsiConnectionType.
+ */
+
+#include "UT_IPSI_UT.hpp"
+#include "ipsi.c"
+#include "stub_UT.c"
+
+
+/**
+ * To perform Unit test on ipsiConnectionType that accept Unique name and
+ * connection type as "Caller"
+ *
+ * Expected Behavior : should return SUCCESS stating that the application
+ * has been registered successfully with IPSI library as Caller
+ */
+static void test_ipcConnectionType_CALLER() {
+	UT_ASSERT (SUCCESS == ipsiConnectionType("demo","Caller"));
+	UT_ASSERT (IPSI_CALLER == applicationRole);
+
+}
+
+/**
+ * To perform Unit test on ipsiConnectionType that accept Unique name and
+ * connection type as "Server"
+ *
+ * Expected Behavior : should return SUCCESS stating that the application
+ * has been registered successfully with IPSI library as Server
+ */
+static void test_ipcConnectionType_SERVER() {
+	UT_ASSERT (SUCCESS == ipsiConnectionType("demo","Server"));
+	UT_ASSERT (IPSI_SERVER == applicationRole);
+
+}
+
+/**
+ * To perform Unit test on ipsiConnectionType while passing Unique name as NULL
+ * and connection type as "Server"
+ *
+ * Expected Behavior : should return Failure
+ */
+static void test_ipcConnectionType_emptyAPPname_Server (){
+	UT_ASSERT (FAILURE == ipsiConnectionType(NULL,"Server"));
+}
+
+/**
+ * To perform Unit test on ipsiConnectionType while passing Unique name  as NULL
+ * and connection type as "Caller"
+ *
+ * Expected Behavior : should return Failure
+ */
+static void test_ipcConnectionType_emptyAPPname_Caller (){
+	UT_ASSERT (FAILURE == ipsiConnectionType(NULL,"Caller"));
+}
+
+/**
+ * To perform Unit test on ipsiConnectionType when dbus_bus_request_name return
+ * Successful by setting an exception which makes dbus_error_is_set to return true.
+ *
+ * Expected Behavior : should return Failure, indicating Dbus connection error
+ */
+static void test_ipcConnectionType_DBUS_GET_CASE2() {
+	conditionCASE = DBUS_GET_CASE2;
+	UT_ASSERT (FAILURE == ipsiConnectionType("demo","Caller"));
+}
+
+/**
+ * To perform Unit test on ipsiConnectionType when dbus_bus_request_name failed to create
+ * DBusConnection and return NULL but no exception was thrown.
+ *
+ * Expected Behavior : should return Failure, indicating Dbus bus connection cannot be established.
+ */
+static void test_ipcConnectionType_DBUS_GET_CASE3() {
+	conditionCASE = DBUS_GET_CASE3;
+	UT_ASSERT (FAILURE == ipsiConnectionType("demo","Caller"));
+}
+
+/**
+ * To perform Unit test on ipsiConnectionType when dbus_bus_request_name return
+ * Successful by setting an exception which makes dbus_error_is_set to return true.
+ *
+ * Expected Behavior : should return Failure, indicating Dbus NAME error.
+ */
+static void test_ipcConnectionType_DBUS_REQUESTNAME_CASE2() {
+	conditionCASE = DBUS_REQUESTNAME_CASE2;
+	UT_ASSERT (FAILURE == ipsiConnectionType("demo","Caller"));
+}
+
+/**
+ * To perform Unit test on ipsiConnectionType when dbus_bus_request_name return by stating that
+ * the connection name that was requested is not a Primary owner of the dbus communication bus.Also
+ * no exception was set by dbus_bus_request_name
+ *
+ * Expected Behavior : should return Failure, indicating requested connection name is not a primary owner.
+ */
+static void test_ipcConnectionType_DBUS_REQUESTNAME_CASE3() {
+	conditionCASE = DBUS_REQUESTNAME_CASE3;
+	UT_ASSERT (FAILURE == ipsiConnectionType("demo","Caller"));
+}
+
+/**
+ * To perform Unit test on ipsiConnectionType when it has been passed with wrong connection type.
+ *
+ * Expected Behavior : should return Failure, indicating connection type is wrong.
+ */
+static void test_ipcConnectionType_connectionTypeNotValid() {
+
+	UT_ASSERT (FAILURE == ipsiConnectionType("demo","ABS"));
+}
+
+/** Unit Testing on ipsiConnectionType Start Here */
+int main()
+{
+	UT_START
+	test_ipcConnectionType_CALLER();
+	test_ipcConnectionType_SERVER();
+	test_ipcConnectionType_emptyAPPname_Server();
+	test_ipcConnectionType_emptyAPPname_Caller();
+	test_ipcConnectionType_DBUS_GET_CASE2();
+	test_ipcConnectionType_DBUS_GET_CASE3();
+	test_ipcConnectionType_DBUS_REQUESTNAME_CASE2();
+	test_ipcConnectionType_DBUS_REQUESTNAME_CASE3();
+	test_ipcConnectionType_connectionTypeNotValid();
+	UT_STOP
+}

--- a/ipsiTest/ut_test/unitTest_ipsiListen_UT.c
+++ b/ipsiTest/ut_test/unitTest_ipsiListen_UT.c
@@ -32,6 +32,7 @@ void dummyFunction (){
  */
 static void test_ipsiListen_PASS(){
 
+	ipsiState = IPSI_GOOD_STATE;
 	ipsiRegisterFunction (dummyFunction,"dummy");
 	UT_ASSERT(SUCCESS == ipsiListen());
 	UT_ASSERT(DUMMY_FUNCTION_CALLED == callFALG);
@@ -51,6 +52,7 @@ static void test_ipsiListen_PASS(){
  */
 static void test_ipsiListen_NoMSG(){
 
+	ipsiState = IPSI_GOOD_STATE;
 	conditionCASE = DBUS_LISTEN_NOMSG_FAULT;
 	ipsiRegisterFunction (dummyFunction,"dummy");
 	UT_ASSERT(FAILURE == ipsiListen());
@@ -68,6 +70,7 @@ static void test_ipsiListen_ipsiClose(){
 	applicationRole = IPSI_SERVER;
 	cleanupFlag = IPSI_CLEAN_UP_SET;
 	ipsiClose();
+	UT_ASSERT(ipsiListenFlag == STOP_IPSI_LISTEN);
 }
 
 /**
@@ -81,6 +84,15 @@ static void test_ipsiListen_ipsiClose_differntApplication(){
 	applicationRole = IPSI_CALLER;
 	cleanupFlag = IPSI_CLEAN_UP_SET;
 	ipsiClose();
+	UT_ASSERT(ipsiListenFlag == STOP_IPSI_LISTEN);
+}
+
+/**
+ * To perform unit testing on ipsiListen , when ipsiConnectionType has set BAD state flag
+ */
+static void test_ipsiListen_ipsiConnectionType_fail(){
+	ipsiState = IPSI_BAD_STATE;
+	UT_ASSERT(FAILURE == ipsiListen());
 }
 
 
@@ -92,6 +104,7 @@ int main()
 	test_ipsiListen_NoMSG();
 	test_ipsiListen_ipsiClose();
 	test_ipsiListen_ipsiClose_differntApplication();
+	test_ipsiListen_ipsiConnectionType_fail();
 	UT_STOP
 
 }

--- a/ipsiTest/ut_test/unitTest_ipsiMethodCall_UT.c
+++ b/ipsiTest/ut_test/unitTest_ipsiMethodCall_UT.c
@@ -15,8 +15,9 @@
  * Expected Behavior: the function return SUCCESS as it was able to place request on
  * dbus session bus, dbus_connection_send was able to send the request on dbus channel
  */
-static void test_ipsiMethoCall_PASS(){
+static void test_ipsiMethodCall_PASS(){
 
+	ipsiState = IPSI_GOOD_STATE; // ipsiConnection was executed successful
 	UT_ASSERT(SUCCESS == ipsiMethodCall("Dummy","Play"));
 }
 
@@ -27,7 +28,8 @@ static void test_ipsiMethoCall_PASS(){
  * Expected Behavior: the function return Failure as it was not able to place request on
  * dbus session bus and dbus_connection_send fails to send request.
  */
-static void test_ipsiMethoCall_SENDFAIL(){
+static void test_ipsiMethodCall_SENDFAIL(){
+	ipsiState = IPSI_GOOD_STATE; // ipsiConnection was executed successful
 	conditionCASE = DBUS_CONNECTION_SEND_FAIL;
 	UT_ASSERT(FAILURE == ipsiMethodCall("Dummy","Play"));
 }
@@ -38,18 +40,28 @@ static void test_ipsiMethoCall_SENDFAIL(){
  * Expected Behavior: the function return Failure as it failed to create valid connection name
  * in order to send request on dbus channel.
  */
-static void test_ipsiMethoCall_appName_NULL(){
+static void test_ipsiMethodCall_appName_NULL(){
 
+	ipsiState = IPSI_GOOD_STATE; // ipsiConnection was executed successful
 	UT_ASSERT(FAILURE == ipsiMethodCall(NULL,"Play"));
+}
+
+/*
+ * To perform unit Testing on ipsiMethodCall when ipsiConnectionType has set BAD state flag
+ */
+static void test_ipsiMethodCall_ipsiCOnectionType_Fail(){
+	ipsiState = IPSI_BAD_STATE; // ipsiConnection was executed successful
+	UT_ASSERT(FAILURE == ipsiMethodCall("Server","Play"));
 }
 
 /** Unit Testing on ipsiMethodCall Start Here */
 int main()
 {
 	UT_START
-	test_ipsiMethoCall_PASS();
-	test_ipsiMethoCall_SENDFAIL();
-	test_ipsiMethoCall_appName_NULL();
+	test_ipsiMethodCall_PASS();
+	test_ipsiMethodCall_SENDFAIL();
+	test_ipsiMethodCall_appName_NULL();
+	test_ipsiMethodCall_ipsiCOnectionType_Fail();
 	UT_STOP
 
 }

--- a/ipsiTest/ut_test/unitTest_isServer_UT.c
+++ b/ipsiTest/ut_test/unitTest_isServer_UT.c
@@ -1,0 +1,49 @@
+/**
+ * @file unitTest_isServer_UT.c
+ *
+ * Description: To perform Unit Testing on isServer .
+ */
+
+#include "UT_IPSI_UT.hpp"
+#include "ipsi.c"
+#include "stub_UT.c"
+
+/**
+ * To perform Unit Testing on isServer when connection type is "Server"
+ *
+ * Expected Behavior: Function should return Success stating the connection type is Server
+ */
+static void test_isServer_Pass(){
+
+	UT_ASSERT(SUCCESS ==(isServer("Server"))); // Check +ive condition
+
+}
+
+/**
+ * To perform Unit Testing on isServer when connection type is not "Server" Type
+ *
+ * Expected Behavior: Function should return Failure stating the connection type is not Server.
+ */
+static void test_isServer_Fail(){
+
+	UT_ASSERT(FAILURE == (isServer("ABC"))); // Check -ive condition
+}
+
+/**
+ * To perform Unit Testing on isServer when connection type is NULL
+ *
+ * Expected Behavior: Function should return Failure stating the connection type is NULL.
+ */
+static void test_isServer_NULL(){
+
+	UT_ASSERT(FAILURE == (isServer(NULL)));
+}
+
+/** Unit Testing for isServer starts */
+int main()
+{
+	UT_START
+	test_isServer_Pass();
+	test_isServer_Fail();
+	test_isServer_NULL();
+}


### PR DESCRIPTION
This Hot-fix handles ipsiConnectionType() failure to form Dbus connection object .  It will not allow ipsiMethodCall and ipsiListen to operate. 
Unit test cases was written in accordance to the changes that was made. Also , other unit cases where changed in order to accommodate the above changes. 